### PR TITLE
[190670] LockNotOwnedError   hct_mis_api.apps.registration_datahub.celery_tasks.check_rdi_import_periodic_task

### DIFF
--- a/backend/hct_mis_api/apps/utils/celery_utils.py
+++ b/backend/hct_mis_api/apps/utils/celery_utils.py
@@ -1,6 +1,14 @@
 from typing import Any, Optional
 
 
+class CeleryConnectionException(Exception):
+    pass
+
+
+def is_celery_working(celery_app: Any) -> bool:
+    return bool(celery_app.control.ping())
+
+
 def format_task(task: dict, status: str) -> dict:
     if "request" in task:
         task = task["request"]
@@ -39,6 +47,9 @@ def get_all_celery_tasks(queue_name: str) -> list:
     from hct_mis_api.apps.core.celery import app as celery_app
 
     all_tasks = []
+
+    if not is_celery_working(celery_app):
+        raise CeleryConnectionException
 
     with celery_app.pool.acquire(block=True) as conn:
         tasks = None


### PR DESCRIPTION
[AB#190670](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/190670)