### PR TITLE
Sentry Fix division by zero

### DIFF
--- a/backend/hct_mis_api/apps/core/tests/test_utils.py
+++ b/backend/hct_mis_api/apps/core/tests/test_utils.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+
+from hct_mis_api.apps.core.utils import get_count_and_percentage
+
+
+class TestCoreUtils(TestCase):
+
+    def test_get_count_and_percentage(self) -> None:
+        self.assertEqual(get_count_and_percentage(1), {"count": 1, "percentage": 100.0})
+        self.assertEqual(get_count_and_percentage(0), {"count": 0, "percentage": 0.0})
+        self.assertEqual(get_count_and_percentage(5, 1), {"count": 5, "percentage": 500.0})
+        self.assertEqual(get_count_and_percentage(20, 20), {"count": 20, "percentage": 100.0})
+        self.assertEqual(get_count_and_percentage(5, 25), {"count": 5, "percentage": 20.0})

--- a/backend/hct_mis_api/apps/core/tests/test_utils.py
+++ b/backend/hct_mis_api/apps/core/tests/test_utils.py
@@ -4,7 +4,6 @@ from hct_mis_api.apps.core.utils import get_count_and_percentage
 
 
 class TestCoreUtils(TestCase):
-
     def test_get_count_and_percentage(self) -> None:
         self.assertEqual(get_count_and_percentage(1), {"count": 1, "percentage": 100.0})
         self.assertEqual(get_count_and_percentage(0), {"count": 0, "percentage": 0.0})

--- a/backend/hct_mis_api/apps/core/utils.py
+++ b/backend/hct_mis_api/apps/core/utils.py
@@ -303,6 +303,7 @@ def nested_dict_get(dictionary: Dict, path: str) -> Optional[str]:
 
 
 def get_count_and_percentage(count: int, all_items_count: int = 1) -> Dict[str, Union[int, float]]:
+    all_items_count = all_items_count or 1  # fix division by zero
     percentage = (count / all_items_count) * 100
     return {"count": count, "percentage": percentage}
 


### PR DESCRIPTION
[AB#195063](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/195063): Sentry: ZeroDivisionError