### PR TITLE
Fix RDI only People sheet validation

### DIFF
--- a/backend/hct_mis_api/apps/registration_datahub/validators.py
+++ b/backend/hct_mis_api/apps/registration_datahub/validators.py
@@ -789,9 +789,10 @@ class UploadXLSXInstanceValidator(ImportDataInstanceValidator):
                 return errors
             errors.extend(self.validate_index_id(wb))
             errors.extend(self.validate_collectors_size(wb))
-            errors.extend(self.validate_collectors(wb))
             if self.is_social_worker_program:
                 errors.extend(self.validate_people_collectors(wb))
+            else:
+                errors.extend(self.validate_collectors(wb))
 
             if not self.is_social_worker_program:
                 individuals_sheet = wb["Individuals"]


### PR DESCRIPTION
[AB#201171](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/201171): RDI - Cannot upload a file of people records that does not contain 'Households'/ 'Individuals' sheet
[AB#197912](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/197912): RDI - Cannot upload excel of people with no clear error