### PR TITLE
Fix AutoCompleteFilter.choices for SoftDeletableModel

### DIFF
--- a/backend/hct_mis_api/apps/core/tests/test_utils.py
+++ b/backend/hct_mis_api/apps/core/tests/test_utils.py
@@ -1,10 +1,6 @@
-from django.contrib.admin.views.main import ChangeList
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 
-from hct_mis_api.apps.core.utils import AutoCompleteFilterTemp, get_count_and_percentage
-from hct_mis_api.apps.targeting.admin import HouseholdSelectionAdmin
-from hct_mis_api.apps.targeting.fixtures import TargetPopulationFactory
-from hct_mis_api.apps.targeting.models import TargetPopulation
+from hct_mis_api.apps.core.utils import get_count_and_percentage
 
 
 class TestCoreUtils(TestCase):
@@ -14,58 +10,3 @@ class TestCoreUtils(TestCase):
         self.assertEqual(get_count_and_percentage(5, 1), {"count": 5, "percentage": 500.0})
         self.assertEqual(get_count_and_percentage(20, 20), {"count": 20, "percentage": 100.0})
         self.assertEqual(get_count_and_percentage(5, 25), {"count": 5, "percentage": 20.0})
-
-
-# temporary added test for AutoCompleteFilterTemp
-class AutoCompleteFilterTempTest(TestCase):
-    def setUp(self) -> None:
-        targeting = TargetPopulationFactory(name="Test TP for test", is_removed=True)
-        self.factory = RequestFactory()
-        self.model_instance = targeting
-        self.filter = AutoCompleteFilterTemp(
-            field=TargetPopulation._meta.get_field("name"),
-            request=self.factory.get("/"),
-            params={},
-            model=TargetPopulation,
-            model_admin=HouseholdSelectionAdmin,
-            field_path="name",
-        )
-
-    def test_choices_method(self) -> None:
-        changelist = ChangeList(
-            self.factory.get("/"),
-            self.filter.model,
-            list_display=[],
-            list_display_links=[],
-            list_filter=[],
-            date_hierarchy=None,
-            search_fields=[],
-            list_select_related=False,
-            list_per_page=10,
-            list_max_show_all=10,
-            list_editable=[],
-            model_admin=None,  # type: ignore
-            sortable_by=["id"],
-        )
-        self.filter.lookup_val = "name"
-        choices = self.filter.choices(changelist)
-        self.assertEqual(choices, [str(self.model_instance)])
-
-        changelist = ChangeList(
-            self.factory.get("/"),
-            self.filter.model,
-            list_display=[],
-            list_display_links=[],
-            list_filter=[],
-            date_hierarchy=None,
-            search_fields=[],
-            list_select_related=False,
-            list_per_page=100,
-            list_max_show_all=200,
-            list_editable=[],
-            model_admin=None,  # type: ignore
-            sortable_by=["id"],
-        )
-        self.filter.lookup_val = ""
-        choices = self.filter.choices(changelist)
-        self.assertEqual(choices, [])

--- a/backend/hct_mis_api/apps/core/tests/test_utils.py
+++ b/backend/hct_mis_api/apps/core/tests/test_utils.py
@@ -1,6 +1,10 @@
-from django.test import TestCase
+from django.contrib.admin.views.main import ChangeList
+from django.test import RequestFactory, TestCase
 
-from hct_mis_api.apps.core.utils import get_count_and_percentage
+from hct_mis_api.apps.core.utils import AutoCompleteFilterTemp, get_count_and_percentage
+from hct_mis_api.apps.targeting.admin import HouseholdSelectionAdmin
+from hct_mis_api.apps.targeting.fixtures import TargetPopulationFactory
+from hct_mis_api.apps.targeting.models import TargetPopulation
 
 
 class TestCoreUtils(TestCase):
@@ -10,3 +14,58 @@ class TestCoreUtils(TestCase):
         self.assertEqual(get_count_and_percentage(5, 1), {"count": 5, "percentage": 500.0})
         self.assertEqual(get_count_and_percentage(20, 20), {"count": 20, "percentage": 100.0})
         self.assertEqual(get_count_and_percentage(5, 25), {"count": 5, "percentage": 20.0})
+
+
+# temporary added test for AutoCompleteFilterTemp
+class AutoCompleteFilterTempTest(TestCase):
+    def setUp(self) -> None:
+        targeting = TargetPopulationFactory(name="Test TP for test", is_removed=True)
+        self.factory = RequestFactory()
+        self.model_instance = targeting
+        self.filter = AutoCompleteFilterTemp(
+            field=TargetPopulation._meta.get_field("name"),
+            request=self.factory.get("/"),
+            params={},
+            model=TargetPopulation,
+            model_admin=HouseholdSelectionAdmin,
+            field_path="name",
+        )
+
+    def test_choices_method(self) -> None:
+        changelist = ChangeList(
+            self.factory.get("/"),
+            self.filter.model,
+            list_display=[],
+            list_display_links=[],
+            list_filter=[],
+            date_hierarchy=None,
+            search_fields=[],
+            list_select_related=False,
+            list_per_page=10,
+            list_max_show_all=10,
+            list_editable=[],
+            model_admin=None,  # type: ignore
+            sortable_by=["id"],
+        )
+        self.filter.lookup_val = "name"
+        choices = self.filter.choices(changelist)
+        self.assertEqual(choices, [str(self.model_instance)])
+
+        changelist = ChangeList(
+            self.factory.get("/"),
+            self.filter.model,
+            list_display=[],
+            list_display_links=[],
+            list_filter=[],
+            date_hierarchy=None,
+            search_fields=[],
+            list_select_related=False,
+            list_per_page=100,
+            list_max_show_all=200,
+            list_editable=[],
+            model_admin=None,  # type: ignore
+            sortable_by=["id"],
+        )
+        self.filter.lookup_val = ""
+        choices = self.filter.choices(changelist)
+        self.assertEqual(choices, [])

--- a/backend/hct_mis_api/apps/core/utils.py
+++ b/backend/hct_mis_api/apps/core/utils.py
@@ -920,7 +920,7 @@ def send_email_notification(
 # https://github.com/saxix/django-adminfilters/blob/676765e3bf25038595a29756014c01e11c5a5d39/src/adminfilters/autocomplete.py#L55
 # not working with .all_objects()
 class AutoCompleteFilterTemp(AutoCompleteFilter):
-    def choices(self, changelist: Any) -> list:  # pragma: no_cover
+    def choices(self, changelist: Any) -> list:
         self.query_string = changelist.get_query_string(remove=[self.lookup_kwarg, self.lookup_kwarg_isnull])
         if self.lookup_val:
             get_kwargs = {self.field.target_field.name: self.lookup_val}

--- a/backend/hct_mis_api/apps/core/utils.py
+++ b/backend/hct_mis_api/apps/core/utils.py
@@ -920,9 +920,9 @@ def send_email_notification(
 # https://github.com/saxix/django-adminfilters/blob/676765e3bf25038595a29756014c01e11c5a5d39/src/adminfilters/autocomplete.py#L55
 # not working with .all_objects()
 class AutoCompleteFilterTemp(AutoCompleteFilter):
-    def choices(self, changelist: Any) -> list:
+    def choices(self, changelist: Any) -> list:  # pragma: no_cover
         self.query_string = changelist.get_query_string(remove=[self.lookup_kwarg, self.lookup_kwarg_isnull])
-        if self.lookup_val:  # pragma: no_cover
+        if self.lookup_val:
             get_kwargs = {self.field.target_field.name: self.lookup_val}
             obj = self.target_model.objects.filter(**get_kwargs) or self.target_model.all_objects.filter(**get_kwargs)
             return [str(obj.first()) or ""]

--- a/backend/hct_mis_api/apps/core/utils.py
+++ b/backend/hct_mis_api/apps/core/utils.py
@@ -922,7 +922,7 @@ def send_email_notification(
 class AutoCompleteFilterTemp(AutoCompleteFilter):
     def choices(self, changelist: Any) -> list:
         self.query_string = changelist.get_query_string(remove=[self.lookup_kwarg, self.lookup_kwarg_isnull])
-        if self.lookup_val:
+        if self.lookup_val:  # pragma: no_cover
             get_kwargs = {self.field.target_field.name: self.lookup_val}
             obj = self.target_model.objects.filter(**get_kwargs) or self.target_model.all_objects.filter(**get_kwargs)
             return [str(obj.first()) or ""]

--- a/backend/hct_mis_api/apps/household/admin/document.py
+++ b/backend/hct_mis_api/apps/household/admin/document.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from adminfilters.autocomplete import AutoCompleteFilter
 from adminfilters.combo import RelatedFieldComboFilter
 
+from hct_mis_api.apps.core.utils import AutoCompleteFilterTemp
 from hct_mis_api.apps.household.models import FOSTER_CHILD, Document, DocumentType
 from hct_mis_api.apps.utils.admin import HOPEModelAdminBase, SoftDeletableAdminMixin
 
@@ -22,7 +23,7 @@ class DocumentAdmin(SoftDeletableAdminMixin, HOPEModelAdminBase):
     raw_id_fields = ("individual", "copied_from", "program")
     list_filter = (
         ("type", RelatedFieldComboFilter),
-        ("individual", AutoCompleteFilter),
+        ("individual", AutoCompleteFilterTemp),
         ("country", AutoCompleteFilter),
     )
     autocomplete_fields = ["type"]

--- a/backend/hct_mis_api/apps/targeting/admin.py
+++ b/backend/hct_mis_api/apps/targeting/admin.py
@@ -14,6 +14,7 @@ from adminfilters.filters import ChoicesFieldComboFilter, MaxMinFilter, ValueFil
 from adminfilters.querystring import QueryStringFilter
 from smart_admin.mixins import LinkedObjectsMixin
 
+from hct_mis_api.apps.core.utils import AutoCompleteFilterTemp
 from hct_mis_api.apps.targeting.celery_tasks import target_population_apply_steficon
 from hct_mis_api.apps.targeting.forms import TargetPopulationForm
 from hct_mis_api.apps.targeting.models import HouseholdSelection, TargetPopulation
@@ -113,7 +114,7 @@ class HouseholdSelectionAdmin(HOPEModelAdminBase, IsOriginalAdminMixin):
         DepotManager,
         QueryStringFilter,
         ("household__unicef_id", ValueFilter),
-        ("target_population", AutoCompleteFilter),
+        ("target_population", AutoCompleteFilterTemp),
         ("target_population__id", ValueFilter),
         ("vulnerability_score", MaxMinFilter),
     )

--- a/backend/hct_mis_api/apps/targeting/tests/test_admin.py
+++ b/backend/hct_mis_api/apps/targeting/tests/test_admin.py
@@ -1,0 +1,26 @@
+from hct_mis_api.apps.household.tests.test_admin import BaseTest
+from hct_mis_api.apps.targeting.fixtures import TargetPopulationFactory
+
+
+# temporary added test for AutoCompleteFilterTemp have to be removed after fix in AutoCompleteFilter
+class HouseholdSelectionAdminTest(BaseTest):
+    def test_household_selection_filtering_by_targeting(self) -> None:
+        base_url = "/api/unicorn/targeting/householdselection/"
+        targeting_removed = TargetPopulationFactory(name="Test TP for test", is_removed=True)
+        targeting_1 = TargetPopulationFactory(name="Test TP for test 222")
+        self.assertTrue(targeting_removed.is_removed)
+        self.assertFalse(targeting_1.is_removed)
+
+        # removed tp
+        url = f"{base_url}?&target_population__exact={str(targeting_removed.id)}"
+        res = self.app.get(url, user=self.superuser)  # noqa: F841
+        self.assertEqual(res.status_code, 200)
+
+        url = f"{base_url}?&target_population__exact={str(targeting_1.id)}"
+        res = self.app.get(url, user=self.superuser)  # noqa: F841
+        self.assertEqual(res.status_code, 200)
+
+        # invalid id
+        url = f"{base_url}?&target_population__exact=00000000-1111-0000-1111-faceb00c1111"
+        res = self.app.get(url, user=self.superuser)  # noqa: F841
+        self.assertEqual(res.status_code, 200)

--- a/backend/hct_mis_api/apps/targeting/tests/test_admin.py
+++ b/backend/hct_mis_api/apps/targeting/tests/test_admin.py
@@ -13,14 +13,14 @@ class HouseholdSelectionAdminTest(BaseTest):
 
         # removed tp
         url = f"{base_url}?&target_population__exact={str(targeting_removed.id)}"
-        res = self.app.get(url, user=self.superuser)  # noqa: F841
+        res = self.app.get(url, user=self.superuser)
         self.assertEqual(res.status_code, 200)
 
         url = f"{base_url}?&target_population__exact={str(targeting_1.id)}"
-        res = self.app.get(url, user=self.superuser)  # noqa: F841
+        res = self.app.get(url, user=self.superuser)
         self.assertEqual(res.status_code, 200)
 
         # invalid id
         url = f"{base_url}?&target_population__exact=00000000-1111-0000-1111-faceb00c1111"
-        res = self.app.get(url, user=self.superuser)  # noqa: F841
+        res = self.app.get(url, user=self.superuser)
         self.assertEqual(res.status_code, 200)


### PR DESCRIPTION
[AB#196493](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/196493): TargetPopulation.DoesNotExist