### PR TITLE
[200869] KOBO - issuing country and document number are not required

### DIFF
--- a/backend/hct_mis_api/apps/registration_datahub/tasks/rdi_kobo_create.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tasks/rdi_kobo_create.py
@@ -140,7 +140,7 @@ class RdiKoboCreateTask(RdiBaseCreateTask):
 
                 is_identity = document_name in identity_fields
 
-                country = Country(data["issuing_country"])
+                country_dict = {"country": Country(data["issuing_country"])} if "issuing_country" in data else {}
 
                 if is_identity:
                     partner = "WFP" if document_name == "scope_id" else "UNHCR"
@@ -148,8 +148,8 @@ class RdiKoboCreateTask(RdiBaseCreateTask):
                         ImportedIndividualIdentity(
                             partner=partner,
                             individual=data["individual"],
-                            document_number=data["number"],
-                            country=country,
+                            document_number=data.get("number", ""),
+                            **country_dict,
                         )
                     )
                     continue
@@ -157,11 +157,11 @@ class RdiKoboCreateTask(RdiBaseCreateTask):
                 file = self._handle_image_field(data.get("photo", ""), False)
                 documents.append(
                     ImportedDocument(
-                        document_number=data["number"],
-                        country=country,
+                        document_number=data.get("number", ""),
                         photo=file,
                         individual=data["individual"],
                         type=document_type,
+                        **country_dict,
                     )
                 )
         ImportedDocument.objects.bulk_create(documents)


### PR DESCRIPTION
[AB#200869](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/200869)

Temporary solution - user can upload only a file for now. In future will change to attachments and the fields on documents will be required